### PR TITLE
Properly animate cell deselection

### DIFF
--- a/FileBrowser/FBFilesTableViewController.m
+++ b/FileBrowser/FBFilesTableViewController.m
@@ -23,7 +23,9 @@
 		self.path = path;
 		
 		self.title = [path lastPathComponent];
-		
+
+        self.clearsSelectionOnViewWillAppear = NO;
+
 		NSError *error = nil;
 		NSArray *tempFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:&error];
 		
@@ -64,6 +66,16 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+
+    NSIndexPath *selectedPath = self.tableView.indexPathForSelectedRow;
+    if (selectedPath) {
+        [self.tableView deselectRowAtIndexPath:selectedPath animated:animated];
+    }
 }
 
 - (void)didReceiveMemoryWarning


### PR DESCRIPTION
Traditionally on iOS, UITableViewCells animate as a view controller is popped. If the interactive swipe back gesture is used, the selection is also interactive. However, UITableView's default `clearsSelectionOnViewWillAppear` does not work properly, so I've implemented the simple fix. 
